### PR TITLE
Add way to specify 'current' path

### DIFF
--- a/lib/s3_deployer/config.rb
+++ b/lib/s3_deployer/config.rb
@@ -9,11 +9,12 @@ class S3Deployer
       @env_settings = {}
       colorize true
       time_zone "GMT"
+      current_path "current"
     end
 
     %w{
       bucket app_name app_path mixbook_host dist_dir access_key_id secret_access_key
-      gzip colorize time_zone
+      gzip colorize time_zone current_path
       before_deploy after_deploy before_stage after_stage before_switch after_switch
     }.each do |method|
       define_method method do |value = :omitted|


### PR DESCRIPTION
It used to be always 'current', but you may want to name it something
else, or even leave it blank, so your app structure would be:

  /20140703171632
  /20140703171633
  /20140703171634
  ...
  index.html
  ...other 'current' files

Also, fix working when app_path is empty (in case you want to host your
static web site directly from S3, like http://your_app.s3.amazonaws.com)
