### PR TITLE
Add generic revisions (not timestamps)

### DIFF
--- a/lib/s3_deployer/config.rb
+++ b/lib/s3_deployer/config.rb
@@ -4,7 +4,10 @@ class S3Deployer
 
     def initialize
       @version = ENV["VERSION"] || ""
-      @revision = ENV["REVISION"] || ""
+      @revision = ENV["REVISION"]
+      @access_key_id = ENV["AWS_ACCESS_KEY_ID"]
+      @secret_access_key = ENV["AWS_SECRET_ACCESS_KEY"]
+      
       @env = ENV["ENV"] || "production"
       @env_settings = {}
       colorize true

--- a/lib/s3_deployer/version.rb
+++ b/lib/s3_deployer/version.rb
@@ -1,3 +1,3 @@
 class S3Deployer
-  VERSION = "0.6.3"
+  VERSION = "0.7.0"
 end


### PR DESCRIPTION
Now you may specify the revision 'stage' and 'switch' will use, which
may not be a timestamp, but something generic (e.g., a git tag)