### PR TITLE
Adding support for session token

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ S3Deployer.configure do
 
   access_key_id 'your S3 access key id'
   secret_access_key 'your S3 secret access key'
+  session_token 'your s3 session token (optional)'
 end
 ```
 

--- a/lib/s3_deployer.rb
+++ b/lib/s3_deployer.rb
@@ -28,7 +28,7 @@ class S3Deployer
 
       Aws.config.update({
         region: config.region,
-        credentials: Aws::Credentials.new(config.access_key_id, config.secret_access_key),
+        credentials: Aws::Credentials.new(config.access_key_id, config.secret_access_key, config.session_token),
       })
     end
 

--- a/lib/s3_deployer/config.rb
+++ b/lib/s3_deployer/config.rb
@@ -7,7 +7,8 @@ class S3Deployer
       @revision = ENV["REVISION"]
       @access_key_id = ENV["AWS_ACCESS_KEY_ID"]
       @secret_access_key = ENV["AWS_SECRET_ACCESS_KEY"]
-      
+      @session_token = ENV["AWS_SESSION_TOKEN"]
+
       @env = ENV["ENV"] || "production"
       @env_settings = {}
       colorize true

--- a/lib/s3_deployer/version.rb
+++ b/lib/s3_deployer/version.rb
@@ -1,3 +1,3 @@
 class S3Deployer
-  VERSION = "0.7.1"
+  VERSION = "0.7.2"
 end


### PR DESCRIPTION
Read session token from config and provide it to the s3 config.  Allows it to be used using keys generated by the aws session token service.